### PR TITLE
Fix for issue #3

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,4 +20,15 @@ Run the script with:
     python download-aura-photos.py
 
 
-Photos will be downloaded to the `images/` folder. The Aura API will throttle the downloads so you may have to restart the script multiple times to fully download all of your photos. The good thing is that download progress is saved so photos that are already downloaded will be skipped when restarting the script. You can also adjust the `time.sleep(2)` to something longer if throttling becomes a problem.
+Photos will be downloaded to the `images/` folder. The Aura API will throttle the downloads 
+so you may have to restart the script multiple times to fully download all of your photos. 
+The good thing is that download progress is saved so photos that are already downloaded 
+will be skipped when restarting the script. You can also adjust the `time.sleep(2)` 
+to something longer if throttling becomes a problem.
+
+The script creates the local picture file name using the 'taken_at' (timestamp) and 
+'file_name' (a uuid and extension) from the item JSON data, so it should be unique 
+for every picture on the frame. 
+Example file name: 2012-04-15-03-15-04.000_B9A0E367-FA8D-4157-A090-7EE33F603312.jpeg
+This will naturally sort the pictures by the date and time taken on most operating 
+systems when you list them.

--- a/download-aura-photos.py
+++ b/download-aura-photos.py
@@ -1,108 +1,117 @@
-import requests
 import json
-import shutil
-import time
 import os
 import os.path
 import re
+import shutil
+import time
+
+import requests
 
 # Put Aura email/password here
 email = "youremail@email.com"
-password =  "yourpassword"
-file_path = "images/"
+password = "yourpassword"
+file_path = "images"
 
 # You can get your frame id by going to app.auraframes.com
 # Log in there and click on "View Photos" underneath your frame
 # Then grab the ID from the URL: https://app.auraframes.com/frame/<FRAME ID HERE>
 frame_id = "your-frame-id"
 
+
 # Main download function
-def download_photos_from_aura( email, password, frame_id):
+def download_photos_from_aura(email, password, frame_id):
+    # define URLs and payload format
+    login_url = "https://api.pushd.com/v5/login.json"
+    frame_url = f"https://api.pushd.com/v5/frames/{frame_id}/assets.json?side_load_users=false"
+    login_payload = {
+        "identifier_for_vendor": "does-not-matter",
+        "client_device_id": "does-not-matter",
+        "app_identifier": "com.pushd.Framelord",
+        "locale": "en",
+        "user": {
+            "email": email,
+            "password": password
+        }
+    }
 
-  # define URLs and payload format
-  login_url = "https://api.pushd.com/v5/login.json"
-  frame_url = "https://api.pushd.com/v5/frames/" + frame_id + "/assets.json?side_load_users=false"
-  login_payload = {
-      "identifier_for_vendor": "does-not-matter",
-      "client_device_id": "does-not-matter",
-      "app_identifier": "com.pushd.Framelord",
-      "locale": "en",
-      "user": {
-          "email": email,
-          "password": password
-      }
-  }
+    # make login request with credentials
+    s = requests.Session()
+    r = s.post(login_url, json=login_payload)
 
-  # make login request with credentials
-  s = requests.Session()
-  r = s.post(login_url, json=login_payload)
+    if r.status_code != 200:
+        print("Login Error: Check your credentials")
+        return 0
 
-  if r.status_code != 200:
-    print("Login Error: Check your credentials")
-    return 0
+    print("Login Success")
 
-  print("Login Success")
+    # get json and update user and auth token headers for next request
+    json_data = r.json()
+    s.headers.update({'X-User-Id': json_data['result']['current_user']['id'],
+                      'X-Token-Auth': json_data['result']['current_user']['auth_token']})
 
-  # get json and update user and auth token headers for next request
-  json_data = r.json()
-  s.headers.update({'X-User-Id': json_data['result']['current_user']['id'],  'X-Token-Auth':  json_data['result']['current_user']['auth_token'] })
+    # make request to get all phtos (frame assets)
+    r = s.get(frame_url)
+    json_data = json.loads(r.text)
+    counter = 0
+    skipped = 0
 
-  # make request to get all phtos (frame assets)
-  r = s.get(frame_url)
-  json_data = json.loads(r.text)
-  counter = 1
+    # check to make sure the frame assets array exists
+    if "assets" not in json_data:
+        print("Download Error: No images returned from this Aura Frame. API responded with:")
+        print(json_data)
+        return 0
 
-  # check to make sure the frame assets array exists
-  if( "assets" not in json_data ):
-    print("Download Error: No images returned from this Aura Frame. API responded with:")
-    print(json_data)
-    return 0
+    photo_count = len(json_data["assets"])
+    print(f"Found {photo_count} photos, starting download process")
+    print("Downloading pictures to filename <taken_at>_<file_name>")
 
-  photo_count = len(json_data["assets"])
-  print( "Found", photo_count, "photos, starting download process")
+    for item in json_data["assets"]:
 
-  for item in json_data["assets"]:
+        try:
+            # construct the raw photo URL
+            url = f"https://imgproxy.pushd.com/{item['user_id']}/{item['file_name']}"
 
-    try:
-      # construct new filename
-      new_filename = re.sub(':|T','-', item["taken_at"]).replace('Z','')
-      if  item["file_name"].endswith(".jpeg"):
-        new_filename = new_filename + ".jpeg"
-      elif  item["file_name"].endswith(".jpg"):
-        new_filename = new_filename + ".jpg"
-      elif  item["file_name"].endswith(".png"):
-        new_filename = new_filename + ".png"
+            # construct new_filename from the taken_at timestamp + photo UUID and extension
+            # construct file_to_write us os.path.join() to handle path delimiters
+            new_filename = re.sub(':|T', '-', item["taken_at"]).replace('Z', '') + "_" + item['file_name']
+            file_to_write = os.path.join(file_path, new_filename)
 
-      # check if file exists and skip it if so
-      if os.path.isfile(file_path + new_filename):
-        print(counter, "Skipping!", new_filename, "already downloaded" )
-        counter = counter + 1
-        continue
+            # Bump the counter and print the new_filename out to track progress
+            counter += 1
 
-      # construct raw photo URL and get it
-      url = "https://imgproxy.pushd.com/" + item["user_id"] + "/" + item["file_name"]
-      print(counter,": Downloading ",item["file_name"])
-      response = requests.get(url, stream=True)
+            # check if file exists and skip it if so
+            if os.path.isfile(file_to_write):
+                print(f"{counter}: Skipping {new_filename}, already downloaded")
+                skipped += 1
+                continue
 
-      # write to a file
-      with open(file_path + new_filename, 'wb') as out_file:
-          shutil.copyfileobj(response.raw, out_file)
-      del response
-      counter = counter + 1
+            # Get the photo from the url
+            print(f"{counter}: Downloading {new_filename}")
+            response = requests.get(url, stream=True)
 
-      # wait a bit to avoid throttling
-      time.sleep(2)
+            # write to a file
+            with open(file_to_write, 'wb') as out_file:
+                shutil.copyfileobj(response.raw, out_file)
+            del response
 
-    except KeyboardInterrupt:
-      print('Exiting from keyboard interrupt')
-      break
+            # wait a bit to avoid throttling
+            time.sleep(2)
 
-    except Exception as e:
-      print("Errored out on item:", counter, "(probably due to throttling)")
-      print(str(e))
-      time.sleep(10)
+        except KeyboardInterrupt:
+            print('Exiting from keyboard interrupt')
+            break
 
-  return counter
+        except Exception as e:
+            print(f"Errored out on item: {counter}, probably due to throttling")
+            print(str(e))
+            time.sleep(10)
 
-total = download_photos_from_aura( email, password, frame_id)
-print("Downloaded", total, "photos")
+    return counter - skipped
+
+# Check the output directory exists in case the script is moved
+# or the file_path is changed.
+if not os.path.isdir(file_path):
+    print(f"Error: output directory {file_path} does not exist")
+else:
+    total = download_photos_from_aura(email, password, frame_id)
+    print(f"Downloaded {total} photos")


### PR DESCRIPTION
README.md - add section describing the new_filename formatREADME.md - add section describing the new_filename format

download-aura-photos.py
    - Exit if file_path directory does not exist
        In case the user moves the script to another dir
        or edits file_path

    - Change print() calls to use f-strings

    - Use os.path.join() to build file_to_write once
        instead of separate string concats

    - Create new_filename from item['taken_at'] and item['file_name']
        This eliminates the issue where if more than one file has the
        same item['taken_at'] only the first one is downloaded by
        appending the frame file_name, which is a uuid to the taken_at
        timestamp.

        Using the item['file_name'] at the end also eliminates
        the need for the 'if' block that appended the file extension to
        new_filename as a separate step.