### PR TITLE
Support passwords with special characters

### DIFF
--- a/download-aura-photos.py
+++ b/download-aura-photos.py
@@ -195,7 +195,7 @@ def app():
     try :
         # Read the frame and login credentials from outside the repo
         LOGGER.info("Using credentials file '%s'", args.config)
-        config = configparser.ConfigParser()
+        config = configparser.ConfigParser(interpolation=None)
         config.read(args.config)
 
         if not config.has_section('login'):


### PR DESCRIPTION
Characters such as % have special meaning to configparser.  If they are used in the password the script will fail parsing.  interpolation=None allows passwords with the special characters to be read without issue.